### PR TITLE
Try to set featured image from post content

### DIFF
--- a/easy-add-thumbnail.php
+++ b/easy-add-thumbnail.php
@@ -51,11 +51,36 @@ function easy_add_thumbnail($post) {
 	        // add attachment ID                                            
 	        add_post_meta( $post->ID, '_thumbnail_id', $attachment_values[0]->ID, true );                                 
 	                        
-	    }
+	    } else {
+			// Get first inserted image ID
+			$inserted_image = easy_get_the_image_id_by_scan( $post->ID );
+			
+			if ( $inserted_image ) {
+				
+				add_post_meta( $post->ID, '_thumbnail_id', $inserted_image, true ); 
+				
+			}
+			
+		}
                            
                          
     }
 
+}
+
+/**
+* Search post content for "wp-image-{$ID}" class to get the attachment ID from it.
+*/
+function easy_get_the_image_id_by_scan( $post_id ) {
+
+	/* Search the post's content for the image id. */
+	preg_match_all( '|wp-image-(.*?)"|i', get_post_field( 'post_content', $post_id ), $matches );
+
+	/* If there is a match for the image, return its ID. */
+	if ( isset( $matches ) && !empty( $matches[1][0] ) )
+		return $matches[1][0];
+
+	return false;
 }
 
 // set featured image before post is displayed (for old posts)


### PR DESCRIPTION
Sometimes the user may insert an image from media lib into post content without attaching it to the post, in this case the plugin will fail to add a featured image to this post.

So, I think it's better to also try to set the featured image by searching the post content for the first image ID depending on the html class "wp-image-{$ID}" which added by WordPress when inserting an image into post content.
